### PR TITLE
fix: call init_logger()

### DIFF
--- a/src/so_vits_svc_fork/__main__.py
+++ b/src/so_vits_svc_fork/__main__.py
@@ -37,6 +37,8 @@ def init_logger() -> None:
         LOG.debug("Test mode is on.")
 
 
+init_logger()
+
 LOG = getLogger(__name__)
 
 


### PR DESCRIPTION
- fixes logger not initialized in multiprocessing