### PR TITLE
fix(logging): initialize logging in logger file and move version log

### DIFF
--- a/src/so_vits_svc_fork/__init__.py
+++ b/src/so_vits_svc_fork/__init__.py
@@ -1,1 +1,5 @@
 __version__ = "1.4.1"
+
+from .logger import init_logger
+
+init_logger()

--- a/src/so_vits_svc_fork/__main__.py
+++ b/src/so_vits_svc_fork/__main__.py
@@ -1,54 +1,23 @@
 from __future__ import annotations
 
 import os
-from logging import (
-    DEBUG,
-    INFO,
-    FileHandler,
-    StreamHandler,
-    basicConfig,
-    captureWarnings,
-    getLogger,
-)
+from logging import getLogger
 from pathlib import Path
 from typing import Literal
 
 import click
 import pyinputplus as pyip
 import torch
-from rich.logging import RichHandler
 
 from so_vits_svc_fork import __version__
 
 LOG = getLogger(__name__)
-LOGGER_INIT = False
 
+IS_TEST = "test" in Path(__file__).parent.stem
+if IS_TEST:
+    LOG.debug("Test mode is on.")
 
-def init_logger() -> None:
-    global LOGGER_INIT
-    if LOGGER_INIT:
-        return
-    IN_COLAB = os.getenv("COLAB_RELEASE_TAG")
-    IS_TEST = "test" in Path(__file__).parent.stem
-
-    basicConfig(
-        level=DEBUG if IS_TEST else INFO,
-        format="%(asctime)s %(message)s",
-        datefmt="[%X]",
-        handlers=[
-            RichHandler() if not IN_COLAB else StreamHandler(),
-            FileHandler(f"{__name__.split('.')[0]}.log"),
-        ],
-    )
-    captureWarnings(True)
-    if IS_TEST:
-        LOG.debug("Test mode is on.")
-
-    LOG.info(f"Version: {__version__}")
-    LOGGER_INIT = True
-
-
-init_logger()
+LOG.info(f"Version: {__version__}")
 
 
 class RichHelpFormatter(click.HelpFormatter):
@@ -100,7 +69,6 @@ def cli():
     To train a model, run pre-resample, pre-config, pre-hubert, train.\n
     To infer a model, run infer.
     """
-    init_logger()
 
 
 @cli.command()

--- a/src/so_vits_svc_fork/gui.py
+++ b/src/so_vits_svc_fork/gui.py
@@ -11,12 +11,10 @@ import torch
 from pebble import ProcessFuture, ProcessPool
 from tqdm.tk import tqdm_tk
 
-from .__main__ import init_logger
 from .utils import ensure_hubert_model
 
 GUI_DEFAULT_PRESETS_PATH = Path(__file__).parent / "default_gui_presets.json"
 GUI_PRESETS_PATH = Path("./user_gui_presets.json").absolute()
-init_logger()
 
 LOG = getLogger(__name__)
 

--- a/src/so_vits_svc_fork/logger.py
+++ b/src/so_vits_svc_fork/logger.py
@@ -1,0 +1,35 @@
+import os
+from logging import (
+    DEBUG,
+    INFO,
+    FileHandler,
+    StreamHandler,
+    basicConfig,
+    captureWarnings,
+)
+from pathlib import Path
+
+from rich.logging import RichHandler
+
+LOGGER_INIT = False
+
+
+def init_logger() -> None:
+    global LOGGER_INIT
+    if LOGGER_INIT:
+        return
+
+    IN_COLAB = os.getenv("COLAB_RELEASE_TAG")
+    IS_TEST = "test" in Path(__file__).parent.stem
+
+    basicConfig(
+        level=DEBUG if IS_TEST else INFO,
+        format="%(asctime)s %(message)s",
+        datefmt="[%X]",
+        handlers=[
+            RichHandler() if not IN_COLAB else StreamHandler(),
+            FileHandler(f"{__name__.split('.')[0]}.log"),
+        ],
+    )
+    captureWarnings(True)
+    LOGGER_INIT = True

--- a/src/so_vits_svc_fork/utils.py
+++ b/src/so_vits_svc_fork/utils.py
@@ -461,7 +461,7 @@ def clean_checkpoints(
     sort_by_time      --  True -> chronologically delete ckpts
                           False -> lexicographically delete ckpts
     """
-    LOG.warning("Cleaning old checkpoints...")
+    LOG.info("Cleaning old checkpoints...")
     path_to_models = Path(path_to_models)
 
     # Define sort key functions
@@ -488,7 +488,7 @@ def clean_checkpoints(
         to_delete_list = list(group_items)[:-n_ckpts_to_keep]
 
         for to_delete in to_delete_list:
-            LOG.warning(f"Removing {to_delete}")
+            LOG.info(f"Removing {to_delete}")
             to_delete.unlink()
 
 


### PR DESCRIPTION
Another attempt at #104 

I've moved the logging intialisation into it's own file `logger.py`
Then inside `__init__.py` I'm importing it and calling the method

I had to move out the version and debug prints into the main file or otherwise they would be printed on every sub-process creation

Running the following 2 commands yields these results:
```
python -c "import so_vits_svc_fork.__main__;from logging import getLogger;getLogger().info('hello')"
python -c "import so_vits_svc_fork.train;from logging import getLogger;getLogger().info('hello')"
```
![image](https://user-images.githubusercontent.com/1345036/227767754-b1895076-457e-4264-980d-e50db5187b6e.png)
