### PR TITLE
feat(yt-tutorial-link): add yt tutorial link above contribs

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ Commands:
   vc             Realtime inference from microphone
 ```
 
+#### External links
+
+[Video Tutorial](https://www.youtube.com/watch?v=tZn0lcGO5OQ)
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):


### PR DESCRIPTION
Tiniest change to add that video tutorial link.

would address: https://github.com/34j/so-vits-svc-fork/issues/138