### PR TITLE
fix: remove possible leak in unused code

### DIFF
--- a/src/so_vits_svc_fork/inference/core.py
+++ b/src/so_vits_svc_fork/inference/core.py
@@ -487,7 +487,7 @@ class RealtimeVC(Crossfader):
             min_rms = 10 ** (db_thresh / 20)
             if rms < min_rms:
                 LOG.info(f"Skip silence: RMS={rms:.2f} < {min_rms:.2f}")
-                return input_audio.copy()
+                return np.zeros_like(input_audio)
             else:
                 LOG.info(f"Start inference: RMS={rms:.2f} >= {min_rms:.2f}")
                 infered_audio_c, _ = self.svc_model.infer(


### PR DESCRIPTION
Nothing every actually sets RealtimeVC.split to False so this section of code goes unused, but this piece of code has a potential leak issue. If the audio is quiet enough to be considered silence, it just pumps the original audio through instead of outputting true silence. If this happens to be a silence misdetection then you possible leak the users' original voice.