### PR TITLE
fix: file not found error in test_preprocess

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,7 +39,7 @@ class TestMain(TestCase):
             "tests/filelists/train.txt",
             "tests/filelists/val.txt",
             "tests/filelists/test.txt",
-            "tests/configs/config.json",
+            "tests/configs/44k/config.json",
         )
 
         if IS_CI:


### PR DESCRIPTION
When running tests, test_preprocess has a file not found error. This appears to be because preprocess_config is saving the config file to tests/configs/config.json, while preprocess_hubert_f0 is trying to load the config file from tests/configs/44k/config.json. If you change the directories to match, this fixes the problem