### PR TITLE
fix(__main__): fix default config type to revert breaking changes

### DIFF
--- a/src/so_vits_svc_fork/__main__.py
+++ b/src/so_vits_svc_fork/__main__.py
@@ -514,7 +514,7 @@ from so_vits_svc_fork.preprocessing.preprocess_flist_config import CONFIG_TEMPLA
     "-t",
     "--config-type",
     type=click.Choice([x.stem for x in CONFIG_TEMPLATE_DIR.rglob("*.json")]),
-    default="so-vits-svc-4.0v1",
+    default="so-vits-svc-4.0v1-legacy",
     help="config type",
 )
 def pre_config(


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ff1a39c</samp>

### Summary
:warning::clock10::gear:

<!--
1.  :warning: This emoji can be used to indicate that the default value of the option has changed and that users should be aware of the potential impact on their existing workflows or scripts that rely on the previous default value.
2.  :clock10: This emoji can be used to indicate that the new default value is a temporary measure and that it will be reverted to the new config template once the service is updated to support it. This emoji can also imply that users should expect another change in the future.
3.  :gear: This emoji can be used to indicate that the change is related to the configuration or settings of the service and that users can still choose a different config template by specifying the option explicitly. This emoji can also imply that the change is technical or internal and not affecting the functionality or performance of the service.
-->
Changed the default config template for the so-vits-svc-fork script to use a legacy version. This ensures compatibility with the current so-vits-svc service.

> _`--config-type` changed_
> _to use legacy template_
> _autumn of service_

### Walkthrough
* Changed the default value of the `--config-type` option to use a legacy config template ([link](https://github.com/34j/so-vits-svc-fork/pull/243/files?diff=unified&w=0#diff-1e96e26cdf5a3809068061c9616dc62d3158dc61dc3e8321ce9310d019430285L517-R517))

