### PR TITLE
fix(train): improve quality of training

### DIFF
--- a/src/so_vits_svc_fork/train.py
+++ b/src/so_vits_svc_fork/train.py
@@ -292,8 +292,8 @@ class VitsLightning(pl.LightningModule):
 
         # generator loss
         LOG.debug("Calculating generator loss")
-        with torch.no_grad():
-            y_d_hat_r, y_d_hat_g, fmap_r, fmap_g = self.net_d(y, y_hat)
+        y_d_hat_r, y_d_hat_g, fmap_r, fmap_g = self.net_d(y, y_hat)
+
         with autocast(enabled=False):
             loss_mel = F.l1_loss(y_mel, y_hat_mel) * self.hparams.train.c_mel
             loss_kl = (

--- a/src/so_vits_svc_fork/train.py
+++ b/src/so_vits_svc_fork/train.py
@@ -400,7 +400,7 @@ class VitsLightning(pl.LightningModule):
                     "gt/mel": utils.plot_spectrogram_to_numpy(mel[0].cpu().numpy()),
                 }
             )
-            if self.current_epoch == 0:
+            if self.current_epoch == 0 or batch_idx != 0:
                 return
             utils.save_checkpoint(
                 self.net_g,

--- a/src/so_vits_svc_fork/train.py
+++ b/src/so_vits_svc_fork/train.py
@@ -183,6 +183,7 @@ class VitsLightning(pl.LightningModule):
 
     def __init__(self, reset_optimizer: bool = False, **hparams: Any):
         super().__init__()
+        self._temp_epoch = 0  # Add this line to initialize the _temp_epoch attribute
         self.save_hyperparameters("reset_optimizer")
         self.save_hyperparameters(*[k for k in hparams.keys()])
         torch.manual_seed(self.hparams.train.seed)

--- a/src/so_vits_svc_fork/train.py
+++ b/src/so_vits_svc_fork/train.py
@@ -240,7 +240,7 @@ class VitsLightning(pl.LightningModule):
             writer.add_audio(
                 k,
                 v,
-                self.trainer.fit_loop.total_batch_idx,
+                self.total_batch_idx,
                 sample_rate=self.hparams.data.sampling_rate,
             )
 

--- a/src/so_vits_svc_fork/train.py
+++ b/src/so_vits_svc_fork/train.py
@@ -354,9 +354,9 @@ class VitsLightning(pl.LightningModule):
             )
 
         # optimizer
+        optim_g.zero_grad()
         self.manual_backward(loss_gen_all)
         optim_g.step()
-        optim_g.zero_grad()
         self.untoggle_optimizer(optim_g)
 
         # Discriminator
@@ -378,9 +378,9 @@ class VitsLightning(pl.LightningModule):
         )
 
         # optimizer
+        optim_d.zero_grad()
         self.manual_backward(loss_disc_all)
         optim_d.step()
-        optim_d.zero_grad()
         self.untoggle_optimizer(optim_d)
 
     def validation_step(self, batch, batch_idx):


### PR DESCRIPTION
This PR includes several things discussed in #270 
- It ensures the `_temp_epoch` variable is initialized in the LightningModule's `__init__` method (thanks @ne0escape)
- It moves the `__init__` method of the LightningModule to the top (bit of cleanup)
- It fixes the order of optimization done to the model as per the Lightning.AI documentation ([lightning.ai/docs/pytorch/stable/common/optimization.html#id2](https://lightning.ai/docs/pytorch/stable/common/optimization.html#id2))
- It removes a `with torch.no_grad():` call for the generator loss calculation which ends up vastly improving the quality of the model (less metallic noise during several tests with a model from scratch)
- It fixes the `log_audio_dict` function so it use the correct `total_batch_idx` value
- It fixes checkpoints saving twice (or multiple times) since `validation_step` is being run for every model apparently (we check if `batch_idx` is 0 and only then save)

Please tell me if you'd like to see any changes made before potentially merging this 🙏 