### PR TITLE
fix(train): fix lr_decay not working

### DIFF
--- a/src/so_vits_svc_fork/train.py
+++ b/src/so_vits_svc_fork/train.py
@@ -418,6 +418,11 @@ class VitsLightning(pl.LightningModule):
         optim_d.step()
         self.untoggle_optimizer(optim_d)
 
+        # end of epoch
+        if self.trainer.is_last_batch:
+            self.scheduler_g.step()
+            self.scheduler_d.step()
+
     def validation_step(self, batch, batch_idx):
         with torch.no_grad():
             self.net_g.eval()


### PR DESCRIPTION
Since we're using manual optimization, we need to call `step()` on each of the learning rate schedulers.
This steps learning rates once per epoch so as to match the behavior before the lightning rewrite.
Relevant docs: https://lightning.ai/docs/pytorch/stable/common/optimization.html#learning-rate-scheduling

Closes #292