### PR TITLE
feat(train): add optional `accumulate_grad_batches` config param

### DIFF
--- a/src/so_vits_svc_fork/train.py
+++ b/src/so_vits_svc_fork/train.py
@@ -392,10 +392,14 @@ class VitsLightning(pl.LightningModule):
                 }
             )
 
+        should_update = (batch_idx + 1) % self.hparams.train.get(
+            "accumulate_grad_batches", 1
+        ) == 0
         # optimizer
-        optim_g.zero_grad()
         self.manual_backward(loss_gen_all)
-        optim_g.step()
+        if should_update:
+            optim_g.step()
+            optim_g.zero_grad()
         self.untoggle_optimizer(optim_g)
 
         # Discriminator
@@ -417,9 +421,10 @@ class VitsLightning(pl.LightningModule):
         )
 
         # optimizer
-        optim_d.zero_grad()
         self.manual_backward(loss_disc_all)
-        optim_d.step()
+        if should_update:
+            optim_d.step()
+            optim_d.zero_grad()
         self.untoggle_optimizer(optim_d)
 
         # end of epoch

--- a/src/so_vits_svc_fork/train.py
+++ b/src/so_vits_svc_fork/train.py
@@ -392,11 +392,10 @@ class VitsLightning(pl.LightningModule):
                 }
             )
 
-        should_update = (batch_idx + 1) % self.hparams.train.get(
-            "accumulate_grad_batches", 1
-        ) == 0
+        accumulate_grad_batches = self.hparams.train.get("accumulate_grad_batches", 1)
+        should_update = (batch_idx + 1) % accumulate_grad_batches == 0
         # optimizer
-        self.manual_backward(loss_gen_all)
+        self.manual_backward(loss_gen_all / accumulate_grad_batches)
         if should_update:
             optim_g.step()
             optim_g.zero_grad()
@@ -421,7 +420,7 @@ class VitsLightning(pl.LightningModule):
         )
 
         # optimizer
-        self.manual_backward(loss_disc_all)
+        self.manual_backward(loss_disc_all / accumulate_grad_batches)
         if should_update:
             optim_d.step()
             optim_d.zero_grad()


### PR DESCRIPTION
Add an optional `accumulate_grad_batches` param to the `train` part of the config to allow for gradient accumulation. ([Lightning docs](https://lightning.ai/docs/pytorch/stable/common/optimization.html#gradient-accumulation))
This updates the gradients once every `accumulate_grad_batches` batches, with a default value of 1 to not break any existing configs.

I went with the same name (`accumulate_grad_batches`) as the [argument to `Trainer`](https://lightning.ai/docs/pytorch/stable/common/trainer.html#accumulate-grad-batches), even though we're not actually using that argument due to doing manual optimization. I realize that might be confusing, so I'm open to suggestions.

I'm relatively new to ML/AI work, so just to double-check my understanding:
- `manual_backward` backpropagates and accumulates gradients
- `step` updates model parameters
- `zero_grad` clears the gradients

So calling `manual_backward`, `step`, `zero_grad` should be equivalent to calling `zero_grad`, `manual_backward`, `step`.

Other considerations:
- Normalize/scale loss by 1 / accumulation steps
  - I looked at [NVIDIA's HiFi-GAN for PyTorch example](https://github.com/NVIDIA/DeepLearningExamples/blob/a6c678ef0323cdaae053e9eed34dce94488ad313/PyTorch/SpeechSynthesis/HiFiGAN/train.py#L389-L390) and they normalize the loss, so I'm pretty sure this is correct
- [We don't need to set `retain_graph=True` because we backpropagate once for each forward pass](https://stackoverflow.com/a/70119359)