### PR TITLE
feat(train): add TensorBoardLogger version parameter support

### DIFF
--- a/src/so_vits_svc_fork/preprocessing/config_templates/quickvc.json
+++ b/src/so_vits_svc_fork/preprocessing/config_templates/quickvc.json
@@ -24,7 +24,8 @@
     "hop_sizes": [60, 120, 20],
     "win_lengths": [300, 600, 120],
     "window": "hann_window",
-    "num_workers": 4
+    "num_workers": 4,
+    "log_version": 0
   },
   "data": {
     "training_files": "filelists/44k/train.txt",

--- a/src/so_vits_svc_fork/preprocessing/config_templates/so-vits-svc-4.0v1-legacy.json
+++ b/src/so_vits_svc_fork/preprocessing/config_templates/so-vits-svc-4.0v1-legacy.json
@@ -20,7 +20,8 @@
     "max_speclen": 512,
     "port": "8001",
     "keep_ckpts": 3,
-    "num_workers": 4
+    "num_workers": 4,
+    "log_version": 0
   },
   "data": {
     "training_files": "filelists/44k/train.txt",

--- a/src/so_vits_svc_fork/preprocessing/config_templates/so-vits-svc-4.0v1.json
+++ b/src/so_vits_svc_fork/preprocessing/config_templates/so-vits-svc-4.0v1.json
@@ -20,7 +20,8 @@
     "max_speclen": 512,
     "port": "8001",
     "keep_ckpts": 3,
-    "num_workers": 4
+    "num_workers": 4,
+    "log_version": 0
   },
   "data": {
     "training_files": "filelists/44k/train.txt",

--- a/src/so_vits_svc_fork/train.py
+++ b/src/so_vits_svc_fork/train.py
@@ -75,7 +75,9 @@ def train(
     )
     LOG.info(f"Using strategy: {strategy}")
     trainer = pl.Trainer(
-        logger=TensorBoardLogger(model_path),
+        logger=TensorBoardLogger(
+            model_path, "lightning_logs", hparams.train.get("log_version", 0)
+        ),
         # profiler="simple",
         val_check_interval=hparams.train.eval_interval,
         max_epochs=hparams.train.epochs,


### PR DESCRIPTION
Closes #319 

By default it will use `version_0` and append new logs to that instead of making new ones.

This can be overriden by the user in the config through the `train.log_version` parameter.