### PR TITLE
fix(train): fix check for notebook / Colab

### DIFF
--- a/src/so_vits_svc_fork/train.py
+++ b/src/so_vits_svc_fork/train.py
@@ -88,7 +88,7 @@ def train(
         if hparams.train.get("bf16_run", False)
         else 32,
         strategy=strategy,
-        callbacks=[pl.callbacks.RichProgressBar()] if is_notebook() else None,
+        callbacks=[pl.callbacks.RichProgressBar()] if not is_notebook() else None,
     )
     model = VitsLightning(reset_optimizer=reset_optimizer, **hparams)
     trainer.fit(model, datamodule=datamodule)


### PR DESCRIPTION
It seems the `is_notebook` check was inverted here, which causes the fancy RichProgressBar to not show up locally (or in that case, actually supported places)

This might also fix #321 