### PR TITLE
fix(train): suppress pytorch logs for deprecated TypedStorage

### DIFF
--- a/src/so_vits_svc_fork/logger.py
+++ b/src/so_vits_svc_fork/logger.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import warnings
 from logging import (
     DEBUG,
     INFO,
@@ -35,6 +36,9 @@ def init_logger() -> None:
     if IS_TEST:
         getLogger(package_name).setLevel(DEBUG)
     captureWarnings(True)
+    warnings.filterwarnings(
+        "ignore", category=UserWarning, message="TypedStorage is deprecated"
+    )
     LOGGER_INIT = True
 
 


### PR DESCRIPTION
As per this issue in the pytorch repository:
https://github.com/pytorch/pytorch/issues/97207

It seems a fix was already included which makes it only log once for the session, instead of every time it's being accessed.

Since this is out of our control as we aren't using any `.storage` (or specifically `TypedStorage`) methods directly I feel it's okay to suppress those warnings.

Closes #330 